### PR TITLE
The stmts property may exist but may be null

### DIFF
--- a/src/Php/PhpPrinterIndentationDetectorVisitor.php
+++ b/src/Php/PhpPrinterIndentationDetectorVisitor.php
@@ -39,7 +39,7 @@ class PhpPrinterIndentationDetectorVisitor extends NodeVisitorAbstract
 			return null;
 		}
 
-		if (count($node->stmts) === 0) {
+		if ($node->stmts === null || count($node->stmts) === 0) {
 			return null;
 		}
 


### PR DESCRIPTION
- [x] I've read the disclaimer "No support is provided outside of bugs impacting development and usage of PHPStan" 😅

I'm trying to use this tool so I can develop my PHPStan extension with modern PHP constructs and then downgrading it so that it can support older PHPs too. I'm not yet sure how exactly it will work, if at all.

Here's one issue I've hit. The `stmts` property can be null in `PhpParser\Node\Stmt\ClassMethod` of abstract methods:
https://github.com/nikic/PHP-Parser/blob/1bcbb2179f97633e98bbbc87044ee2611c7d7999/lib/PhpParser/Node/Stmt/ClassMethod.php#L20-L21