### PR TITLE
Add GitHub Action timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
   lint:
     name: "Lint"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
@@ -46,6 +47,7 @@ jobs:
     name: "Coding Standard"
 
     runs-on: "ubuntu-latest"
+    timeout-minutes: 10
 
     steps:
       - name: "Checkout"
@@ -72,6 +74,7 @@ jobs:
   tests:
     name: "Tests"
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false
@@ -111,6 +114,7 @@ jobs:
   static-analysis:
     name: "PHPStan"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     name: "Integration Test"
     runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 10
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
to make sure jobs don't waste endless resources like seen in https://github.com/ondrejmirtes/simple-downgrader/pull/7

![grafik](https://github.com/user-attachments/assets/43c7bb85-1976-4471-a2c8-e89f0a732686)
