### PR TITLE
Made DowngradeNamedArgumentsVisitorTest not require classes from phpstorm-stubs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     name: "Integration Test"
     runs-on: ${{ matrix.operating-system }}
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /composer.lock
 /.phpunit.result.cache
+tests/tmp/clover.xml

--- a/tests/Fixtures/MyDeprecated.php
+++ b/tests/Fixtures/MyDeprecated.php
@@ -14,7 +14,8 @@ class MyDeprecated
 
 	public function __construct(?string $message = null, ?string $since = null)
 	{
-		/* … */
+		$this->message = $message;
+		$this->since = $since;
 	}
 
 }

--- a/tests/Fixtures/MyDeprecated.php
+++ b/tests/Fixtures/MyDeprecated.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SimpleDowngrader\Fixtures;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::TARGET_CLASS_CONSTANT | Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::TARGET_CONSTANT)]
+class MyDeprecated
+{
+	public ?string $message;
+
+	public ?string $since;
+
+	public function __construct(?string $message = null, ?string $since = null) { /* … */ }
+
+}

--- a/tests/Fixtures/MyDeprecated.php
+++ b/tests/Fixtures/MyDeprecated.php
@@ -1,16 +1,20 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace SimpleDowngrader\Fixtures;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::TARGET_CLASS_CONSTANT | Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::TARGET_CONSTANT)]
+#[Attribute(Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::TARGET_CLASS_CONSTANT | Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class MyDeprecated
 {
+
 	public ?string $message;
 
 	public ?string $since;
 
-	public function __construct(?string $message = null, ?string $since = null) { /* … */ }
+	public function __construct(?string $message = null, ?string $since = null)
+	{
+		/* … */
+	}
 
 }

--- a/tests/Visitor/DowngradeNamedArgumentsVisitorTest.php
+++ b/tests/Visitor/DowngradeNamedArgumentsVisitorTest.php
@@ -40,6 +40,7 @@ class StreamOutput
 PHP,
 				$astLocator,
 			),
+			new DirectoriesSourceLocator([__DIR__ . '/../../tests/Fixtures'], $astLocator),
 			new DirectoriesSourceLocator([__DIR__ . '/../../vendor/jetbrains/phpstorm-stubs/meta/attributes'], $astLocator),
 			new PhpInternalSourceLocator($astLocator, $sourceStubber),
 		])));
@@ -51,7 +52,7 @@ PHP,
 			<<<'PHP'
 <?php
 
-#[\Deprecated(since: 'foo', message: 'bar')]
+#[\SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo', message: 'bar')]
 class Foo
 {
 }
@@ -60,7 +61,7 @@ PHP
 			<<<'PHP'
 <?php
 
-#[\Deprecated('bar', 'foo')]
+#[\SimpleDowngrader\Fixtures\MyDeprecated('bar', 'foo')]
 class Foo
 {
 }
@@ -74,7 +75,7 @@ PHP
 
 use Deprecated;
 
-#[Deprecated(since: 'foo', message: 'bar')]
+#[SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo', message: 'bar')]
 class Foo
 {
 }
@@ -85,7 +86,7 @@ PHP
 
 use Deprecated;
 
-#[Deprecated('bar', 'foo')]
+#[SimpleDowngrader\Fixtures\MyDeprecated('bar', 'foo')]
 class Foo
 {
 }
@@ -97,7 +98,7 @@ PHP
 			<<<'PHP'
 <?php
 
-#[\Deprecated(since: 'foo')]
+#[\SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo')]
 class Foo
 {
 }
@@ -106,7 +107,7 @@ PHP
 			<<<'PHP'
 <?php
 
-#[\Deprecated(\null, 'foo')]
+#[\SimpleDowngrader\Fixtures\MyDeprecated(null, 'foo')]
 class Foo
 {
 }
@@ -279,7 +280,7 @@ PHP,
 class Foo
 {
 	public function __construct(
-		#[\JetBrains\PhpStorm\Deprecated(replacement: 'foo')]
+		#[\SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo')]
 		public int $foo,
 	)
 	{
@@ -293,7 +294,7 @@ PHP
 class Foo
 {
 	public function __construct(
-		#[\JetBrains\PhpStorm\Deprecated("", 'foo')]
+		#[\SimpleDowngrader\Fixtures\MyDeprecated(null, 'foo')]
 		public int $foo,
 	)
 	{

--- a/tests/Visitor/DowngradeNamedArgumentsVisitorTest.php
+++ b/tests/Visitor/DowngradeNamedArgumentsVisitorTest.php
@@ -73,9 +73,9 @@ PHP
 			<<<'PHP'
 <?php
 
-use Deprecated;
+use SimpleDowngrader\Fixtures\MyDeprecated;
 
-#[SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo', message: 'bar')]
+#[MyDeprecated(since: 'foo', message: 'bar')]
 class Foo
 {
 }
@@ -84,9 +84,9 @@ PHP
 			<<<'PHP'
 <?php
 
-use Deprecated;
+use SimpleDowngrader\Fixtures\MyDeprecated;
 
-#[SimpleDowngrader\Fixtures\MyDeprecated('bar', 'foo')]
+#[MyDeprecated('bar', 'foo')]
 class Foo
 {
 }

--- a/tests/Visitor/DowngradeNamedArgumentsVisitorTest.php
+++ b/tests/Visitor/DowngradeNamedArgumentsVisitorTest.php
@@ -41,7 +41,6 @@ PHP,
 				$astLocator,
 			),
 			new DirectoriesSourceLocator([__DIR__ . '/../../tests/Fixtures'], $astLocator),
-			new DirectoriesSourceLocator([__DIR__ . '/../../vendor/jetbrains/phpstorm-stubs/meta/attributes'], $astLocator),
 			new PhpInternalSourceLocator($astLocator, $sourceStubber),
 		])));
 	}

--- a/tests/Visitor/DowngradeNamedArgumentsVisitorTest.php
+++ b/tests/Visitor/DowngradeNamedArgumentsVisitorTest.php
@@ -51,7 +51,7 @@ PHP,
 			<<<'PHP'
 <?php
 
-#[\JetBrains\PhpStorm\Deprecated(replacement: 'foo', reason: 'bar')]
+#[\Deprecated(since: 'foo', message: 'bar')]
 class Foo
 {
 }
@@ -60,7 +60,7 @@ PHP
 			<<<'PHP'
 <?php
 
-#[\JetBrains\PhpStorm\Deprecated('bar', 'foo')]
+#[\Deprecated('bar', 'foo')]
 class Foo
 {
 }
@@ -72,9 +72,9 @@ PHP
 			<<<'PHP'
 <?php
 
-use JetBrains\PhpStorm\Deprecated;
+use Deprecated;
 
-#[Deprecated(replacement: 'foo', reason: 'bar')]
+#[Deprecated(since: 'foo', message: 'bar')]
 class Foo
 {
 }
@@ -83,7 +83,7 @@ PHP
 			<<<'PHP'
 <?php
 
-use JetBrains\PhpStorm\Deprecated;
+use Deprecated;
 
 #[Deprecated('bar', 'foo')]
 class Foo
@@ -97,7 +97,7 @@ PHP
 			<<<'PHP'
 <?php
 
-#[\JetBrains\PhpStorm\Deprecated(replacement: 'foo')]
+#[\Deprecated(since: 'foo')]
 class Foo
 {
 }
@@ -106,7 +106,7 @@ PHP
 			<<<'PHP'
 <?php
 
-#[\JetBrains\PhpStorm\Deprecated("", 'foo')]
+#[\Deprecated(\null, 'foo')]
 class Foo
 {
 }

--- a/tests/Visitor/DowngradePropertyPromotionVisitorTest.php
+++ b/tests/Visitor/DowngradePropertyPromotionVisitorTest.php
@@ -234,7 +234,7 @@ PHP
 class Foo
 {
 	public function __construct(
-		#[\JetBrains\PhpStorm\Deprecated(replacement: 'foo')]
+		#[\SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo')]
 		public int $foo,
 	)
 	{
@@ -247,10 +247,10 @@ PHP
 
 class Foo
 {
-	#[\JetBrains\PhpStorm\Deprecated(replacement: 'foo')]
+	#[\SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo')]
 	public int $foo;
 	public function __construct(
-		#[\JetBrains\PhpStorm\Deprecated(replacement: 'foo')]
+		#[\SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo')]
 		int $foo
 	)
 	{
@@ -262,9 +262,9 @@ PHP : <<<'PHP'
 
 class Foo
 {
-	#[\JetBrains\PhpStorm\Deprecated(replacement: 'foo')]
+	#[\SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo')]
 	public int $foo;
-	public function __construct(#[\JetBrains\PhpStorm\Deprecated(replacement: 'foo')] int $foo)
+	public function __construct(#[\SimpleDowngrader\Fixtures\MyDeprecated(since: 'foo')] int $foo)
 	{
 		$this->foo = $foo;
 	}


### PR DESCRIPTION
we don't need support for this particular attribute while downgrading.

this eases the POC for using runtime reflection instead of static reflection.
thesis is we get a faster downgrade on php 7.4 when we can use runtime reflection over static reflection.

downgrading code to php 7.4 is currenty the slowest step when testing phpstan-src in CI on php 7.4 (takes multiple minutes)