### PR TITLE
Cancel in-flight builds on subsequent pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - "2.x"
 
+concurrency:
+  group: build-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: "Lint"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - "2.x"
 
+concurrency:
+  group: tests-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "Integration Test"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,7 +9,7 @@ on:
       - "2.x"
 
 concurrency:
-  group: tests-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
+  group: integration-tests-${{ github.head_ref || github.run_id }} # will be canceled on subsequent pushes in pull requests but not branches
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
the build take a pretty long time. cancel jobs on old pull request branch commits, to make room for the newly pushed commits