### PR TITLE
Made Scope&NodeCallbackInvoker downgrade independent of order

### DIFF
--- a/src/Visitor/DowngradePureIntersectionTypeVisitor.php
+++ b/src/Visitor/DowngradePureIntersectionTypeVisitor.php
@@ -10,6 +10,7 @@ use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use function array_map;
 use function count;
+use function in_array;
 
 class DowngradePureIntersectionTypeVisitor extends NodeVisitorAbstract
 {
@@ -33,13 +34,18 @@ class DowngradePureIntersectionTypeVisitor extends NodeVisitorAbstract
 				return null;
 			},
 			static function (TypeNode $resultType): ?Name {
+				$scopeCallbackInterfaceNames = [
+					'\PHPStan\Analyser\Scope',
+					'\PHPStan\Analyser\NodeCallbackInvoker',
+				];
+
 				if (
 					$resultType instanceof IntersectionTypeNode
 					&& count($resultType->types) === 2
 					&& $resultType->types[0] instanceof IdentifierTypeNode
-					&& $resultType->types[0]->name === '\PHPStan\Analyser\Scope'
 					&& $resultType->types[1] instanceof IdentifierTypeNode
-					&& $resultType->types[1]->name === '\PHPStan\Analyser\NodeCallbackInvoker'
+					&& in_array($resultType->types[0]->name, $scopeCallbackInterfaceNames, true)
+					&& in_array($resultType->types[1]->name, $scopeCallbackInterfaceNames, true)
 				) {
 					return new Name('\PHPStan\Analyser\Scope');
 				}

--- a/tests/Visitor/DowngradePureIntersectionTypeVisitorTest.php
+++ b/tests/Visitor/DowngradePureIntersectionTypeVisitorTest.php
@@ -181,6 +181,38 @@ class MyRule
 PHP
 ,
 		];
+
+		yield [
+			<<<'PHP'
+<?php
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\NodeCallbackInvoker;
+
+class MyRule
+{
+    public function processNode(Node $node, NodeCallbackInvoker&Scope $scope): array
+    {}
+}
+PHP
+,
+			<<<'PHP'
+<?php
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\NodeCallbackInvoker;
+
+class MyRule
+{
+    /**
+     * @param \PHPStan\Analyser\NodeCallbackInvoker&\PHPStan\Analyser\Scope $scope
+     */
+    public function processNode(Node $node, \PHPStan\Analyser\Scope $scope): array
+    {}
+}
+PHP
+,
+		];
 	}
 
 }


### PR DESCRIPTION
Support `NodeCallbackInvoker&Scope` in addition to `Scope&NodeCallbackInvoker`