### PR TITLE
CI: Don't lint on windows

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -33,8 +33,20 @@ jobs:
           - "lowest"
           - "highest"
         script:
-          - "make lint"
           - "make phpstan"
+        include:
+            - operating-system: ubuntu-latest
+              php-version: "7.4"
+              dependencies: "lowest"
+              script: "make lint"
+            - operating-system: ubuntu-latest
+              php-version: "8.0"
+              dependencies: "lowest"
+              script: "make lint"
+            - operating-system: ubuntu-latest
+              php-version: "8.1"
+              dependencies: "lowest"
+              script: "make lint"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
our `make lint` command meanwhile contains so many `--exclude ...` options that the command no longer works on windows - [see debugging result](https://github.com/ondrejmirtes/simple-downgrader/pull/22#issuecomment-3951083875).

the command gets cut and we ran into a "Invalid option" error.
on phpstan-src we don't run `make lint` on windows either (thats why we did not realize that the exclude list overgrew and started erroring).