### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,7 @@
 		"symfony/console": "^5.4.47",
 		"nette/utils": "^3.2.5",
 		"symfony/finder": "^5.4.45",
-		"phpstan/phpdoc-parser": "^2.0",
-		"symfony/polyfill-php80": "^1.32"
+		"phpstan/phpdoc-parser": "^2.0"
 	},
 	"bin": [
 		"bin/simple-downgrade"


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: ^8.2`, so the polyfill requirement doesn't seem necessary anymore?